### PR TITLE
fixed duplication, not parsing the correct value for content

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ $addNewButton.on('click', function(event) {
 $newForm.on('submit', function(event){
   event.preventDefault()
   var title = $(this).find("input[name='title']").val()
-  var content = $(this).find("input[name='title']").val()
+  var content = $(this).find("input[name='content']").val()
   $postDiv.append(postHTML(title, content))
   hideForm()
 })


### PR DESCRIPTION
@laurenfazah @case-eee @kat3kasper We didn't go over this as an error today in the lesson so I wonder if `index.js:line 18` is just a typo. 

It looks like the original `index.js` file was setting the same value to two different variables `title` & `content`. See below.
### Original: 
```
var title = $(this).find("input[name='title']").val() // line 17
var content = $(this).find("input[name='title']").val() // line 18
```
When our test input is entered into the form once the appropriate changes have been made to get the page working, it returns a duplication of the title (see below)
### Input: 
![screen shot 2017-10-04 at 10 55 53 am](https://user-images.githubusercontent.com/25143074/31188659-df8e8d48-a8f2-11e7-90fa-2c8b6db7322e.png)
### Output:  
![screen shot 2017-10-04 at 10 56 28 am](https://user-images.githubusercontent.com/25143074/31188692-ff4497ea-a8f2-11e7-942f-8a6ec92fc772.png)

However, our `form` variable has both `title` and `content` as input names that should be holding different values.
```
var form = "<form class='new-form'>Title: <input type='text' name='title'><br>Content: <input type='text' name='content'><br><input type='submit'></form>" // line 9
```

### Proposed Fix:
```
var title = $(this).find("input[name='title']").val() 
var content = $(this).find("input[name='content']").val() // sets the correct value to the variable content
```

When our test input is entered into the form once the appropriate changes have been made to get the page working, it returns both the title and the content (see below)
### Input: 
![screen shot 2017-10-04 at 10 55 53 am](https://user-images.githubusercontent.com/25143074/31188659-df8e8d48-a8f2-11e7-90fa-2c8b6db7322e.png)
### Output: 
![screen shot 2017-10-04 at 10 56 52 am](https://user-images.githubusercontent.com/25143074/31188721-130abdae-a8f3-11e7-8e82-a607158c6894.png)

Let me know if you have questions or feedback!
